### PR TITLE
add invite_template_id to stytch call

### DIFF
--- a/lib/stytch/magic_links.rb
+++ b/lib/stytch/magic_links.rb
@@ -117,6 +117,7 @@ module Stytch
         email:,
         invite_magic_link_url: nil,
         invite_expiration_minutes: nil,
+        invite_template_id: nil,
         attributes: {},
         name: {}
       )
@@ -126,6 +127,7 @@ module Stytch
 
         request[:invite_magic_link_url] = invite_magic_link_url unless invite_magic_link_url.nil?
         request[:invite_expiration_minutes] = invite_expiration_minutes unless invite_expiration_minutes.nil?
+        request[:invite_template_id] = invite_template_id unless invite_template_id.nil?
         request[:attributes] = attributes if attributes != {}
         request[:name] = name if name != {}
 


### PR DESCRIPTION
In order to use custom email templates with Stytch we need to pass in the `template_id` through the Stytch API. This can't be done through the dashboard and needs to be done through the API.

https://stytch.com/docs/api/invite-by-email